### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2018 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/composer-json-normalizer
+@see https://github.com/ergebnis/composer-json-normalizer
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ For a full diff see [`1.0.2...master`][1.0.2...master].
 ### Changed
 
 * Started using `ergebnis/json-normalizer` instead of `localheinz/json-normalizer` ([#44]), by [@localheinz]
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#45]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/composer-json-normalizer
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/composer-json-normalizer
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\Composer\\Json\\Normalizer/Ergebnis\\Composer\\Json\\Normalizer/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\Composer\Json\Normalizer` with `Ergebnis\Composer\Json\Normalizer`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
@@ -42,20 +73,22 @@ For a full diff see [`149a393...1.0.0`][149a393...1.0.0].
 
 * Imported all of the normalizers from [`localheinz/json-normalizer`](https://github.com/localheinz/composer-normalize/tree/dcf55c24e2dfa49f7be594bfe50aa3c636b84501) ([#1]), by [@localheinz]
 
-[1.0.0]: https://github.com/localheinz/composer-json-normalizer/releases/tag/1.0.0
-[1.0.1]: https://github.com/localheinz/composer-json-normalizer/releases/tag/1.0.1
-[1.0.2]: https://github.com/localheinz/composer-json-normalizer/releases/tag/1.0.2
+[1.0.0]: https://github.com/ergebnis/composer-json-normalizer/releases/tag/1.0.0
+[1.0.1]: https://github.com/ergebnis/composer-json-normalizer/releases/tag/1.0.1
+[1.0.2]: https://github.com/ergebnis/composer-json-normalizer/releases/tag/1.0.2
 
-[149a393...1.0.0]: https://github.com/localheinz/composer-json-normalizer/compare/149a393...1.0.0
-[1.0.0...1.0.1]: https://github.com/localheinz/composer-json-normalizer/compare/1.0.0...1.0.1
-[1.0.1...1.0.2]: https://github.com/localheinz/composer-json-normalizer/compare/1.0.1...1.0.2
-[1.0.2...master]: https://github.com/localheinz/composer-json-normalizer/compare/1.0.2...master
+[149a393...1.0.0]: https://github.com/ergebnis/composer-json-normalizer/compare/149a393...1.0.0
+[1.0.0...1.0.1]: https://github.com/ergebnis/composer-json-normalizer/compare/1.0.0...1.0.1
+[1.0.1...1.0.2]: https://github.com/ergebnis/composer-json-normalizer/compare/1.0.1...1.0.2
+[1.0.2...master]: https://github.com/ergebnis/composer-json-normalizer/compare/1.0.2...master
 
-[#1]: https://github.com/localheinz/composer-json-normalizer/pull/1
-[#2]: https://github.com/localheinz/composer-json-normalizer/pull/2
-[#21]: https://github.com/localheinz/composer-json-normalizer/pull/21
-[#30]: https://github.com/localheinz/composer-json-normalizer/pull/30
-[#41]: https://github.com/localheinz/composer-json-normalizer/pull/41
-[#44]: https://github.com/localheinz/composer-json-normalizer/pull/44
+[#1]: https://github.com/ergebnis/composer-json-normalizer/pull/1
+[#2]: https://github.com/ergebnis/composer-json-normalizer/pull/2
+[#21]: https://github.com/ergebnis/composer-json-normalizer/pull/21
+[#30]: https://github.com/ergebnis/composer-json-normalizer/pull/30
+[#41]: https://github.com/ergebnis/composer-json-normalizer/pull/41
+[#44]: https://github.com/ergebnis/composer-json-normalizer/pull/44
+[#45]: https://github.com/ergebnis/composer-json-normalizer/pull/45
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # composer-json-normalizer
 
-[![Continuous Integration](https://github.com/localheinz/composer-json-normalizer/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/composer-json-normalizer/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/composer-json-normalizer/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/composer-json-normalizer)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/composer-json-normalizer/v/stable)](https://packagist.org/packages/localheinz/composer-json-normalizer)
-[![Total Downloads](https://poser.pugx.org/localheinz/composer-json-normalizer/downloads)](https://packagist.org/packages/localheinz/composer-json-normalizer)
+[![Continuous Integration](https://github.com/ergebnis/composer-json-normalizer/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/composer-json-normalizer/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/composer-json-normalizer/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/composer-json-normalizer)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/composer-json-normalizer/v/stable)](https://packagist.org/packages/ergebnis/composer-json-normalizer)
+[![Total Downloads](https://poser.pugx.org/ergebnis/composer-json-normalizer/downloads)](https://packagist.org/packages/ergebnis/composer-json-normalizer)
 
 Provides normalizers for normalizing [`composer.json`](https://getcomposer.org/doc/04-schema.md).
 
@@ -12,19 +12,19 @@ Provides normalizers for normalizing [`composer.json`](https://getcomposer.org/d
 Run
 
 ```
-$ composer require localheinz/composer-json-normalizer
+$ composer require ergebnis/composer-json-normalizer
 ```
 
 ## Usage
 
-Create an instance of `Localheinz\Composer\Json\Normalizer\ComposerJsonNormalizer`
+Create an instance of `Ergebnis\Composer\Json\Normalizer\ComposerJsonNormalizer`
 and use it to normalize the contents of a `composer.json`:
 
 ```php
 <?php
 
+use Ergebnis\Composer\Json\Normalizer\ComposerJsonNormalizer;
 use Ergebnis\Json\Normalizer\Json;
-use Localheinz\Composer\Json\Normalizer\ComposerJsonNormalizer;
 
 $normalizer = new ComposerJsonNormalizer();
 
@@ -46,10 +46,10 @@ The `ComposerJsonNormalizer` composes normalizers provided by [`localheinz/json-
 
 as well as the following normalizers provided by this package:
 
-* [`Localheinz\Composer\Json\Normalizer\BinNormalizer`](#binnormalizer)
-* [`Localheinz\Composer\Json\Normalizer\ConfigHashNormalizer`](#confighashnormalizer)
-* [`Localheinz\Composer\Json\Normalizer\PackageHashNormalizer`](#packagehashnormalizer)
-* [`Localheinz\Composer\Json\Normalizer\VersionConstraintNormalizer`](#versionconstraintnormalizer)
+* [`Ergebnis\Composer\Json\Normalizer\BinNormalizer`](#binnormalizer)
+* [`Ergebnis\Composer\Json\Normalizer\ConfigHashNormalizer`](#confighashnormalizer)
+* [`Ergebnis\Composer\Json\Normalizer\PackageHashNormalizer`](#packagehashnormalizer)
+* [`Ergebnis\Composer\Json\Normalizer\VersionConstraintNormalizer`](#versionconstraintnormalizer)
 
 ### `BinNormalizer`
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/composer-json-normalizer",
+  "name": "ergebnis/composer-json-normalizer",
   "type": "library",
   "description": "Provides normalizers for normalizing composer.json.",
   "keywords": [
@@ -7,7 +7,7 @@
     "json",
     "normalizer"
   ],
-  "homepage": "https://github.com/localheinz/composer-json-normalizer",
+  "homepage": "https://github.com/ergebnis/composer-json-normalizer",
   "license": "MIT",
   "authors": [
     {
@@ -39,16 +39,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Composer\\Json\\Normalizer\\": "src/"
+      "Ergebnis\\Composer\\Json\\Normalizer\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Composer\\Json\\Normalizer\\Test\\": "test/"
+      "Ergebnis\\Composer\\Json\\Normalizer\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/composer-json-normalizer/issues",
-    "source": "https://github.com/localheinz/composer-json-normalizer"
+    "issues": "https://github.com/ergebnis/composer-json-normalizer/issues",
+    "source": "https://github.com/ergebnis/composer-json-normalizer"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12c8272cf61cb9286ed1adbc0cbc5683",
+    "content-hash": "8b7b48f861312f48b176739ab293f07b",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,7 +3,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Constructor in Localheinz\\\\Composer\\\\Json\\\\Normalizer\\\\ComposerJsonNormalizer has parameter \\$schemaUri with default value\\.$#"
+			message: "#^Constructor in Ergebnis\\\\Composer\\\\Json\\\\Normalizer\\\\ComposerJsonNormalizer has parameter \\$schemaUri with default value\\.$#"
 			count: 1
 			path: src/ComposerJsonNormalizer.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ includes:
 parameters:
 	ergebnis:
 		classesAllowedToBeExtended:
-			- Localheinz\Composer\Json\Normalizer\Test\Unit\AbstractNormalizerTestCase
+			- Ergebnis\Composer\Json\Normalizer\Test\Unit\AbstractNormalizerTestCase
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:

--- a/src/BinNormalizer.php
+++ b/src/BinNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer;
+namespace Ergebnis\Composer\Json\Normalizer;
 
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Normalizer\NormalizerInterface;

--- a/src/ComposerJsonNormalizer.php
+++ b/src/ComposerJsonNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer;
+namespace Ergebnis\Composer\Json\Normalizer;
 
 use Ergebnis\Json\Normalizer;
 use JsonSchema\SchemaStorage;

--- a/src/ConfigHashNormalizer.php
+++ b/src/ConfigHashNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer;
+namespace Ergebnis\Composer\Json\Normalizer;
 
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Normalizer\NormalizerInterface;

--- a/src/PackageHashNormalizer.php
+++ b/src/PackageHashNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer;
+namespace Ergebnis\Composer\Json\Normalizer;
 
 use Composer\Repository;
 use Ergebnis\Json\Normalizer\Json;

--- a/src/VersionConstraintNormalizer.php
+++ b/src/VersionConstraintNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer;
+namespace Ergebnis\Composer\Json\Normalizer;
 
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Normalizer\NormalizerInterface;

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer\Test\AutoReview;
+namespace Ergebnis\Composer\Json\Normalizer\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\Composer\\Json\\Normalizer\\',
-            'Localheinz\\Composer\\Json\\Normalizer\\Test\\Unit\\'
+            'Ergebnis\\Composer\\Json\\Normalizer\\',
+            'Ergebnis\\Composer\\Json\\Normalizer\\Test\\Unit\\'
         );
     }
 }

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer\Test\AutoReview;
+namespace Ergebnis\Composer\Json\Normalizer\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;

--- a/test/Unit/AbstractNormalizerTestCase.php
+++ b/test/Unit/AbstractNormalizerTestCase.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Composer\Json\Normalizer\Test\Unit;
 
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Normalizer\NormalizerInterface;
@@ -76,8 +76,8 @@ abstract class AbstractNormalizerTestCase extends Framework\TestCase
             '/Test$/',
             '',
             \str_replace(
-                'Localheinz\\Composer\\Json\\Normalizer\\Test\\Unit\\',
-                'Localheinz\\Composer\\Json\\Normalizer\\',
+                'Ergebnis\\Composer\\Json\\Normalizer\\Test\\Unit\\',
+                'Ergebnis\\Composer\\Json\\Normalizer\\',
                 static::class
             )
         );

--- a/test/Unit/BinNormalizerTest.php
+++ b/test/Unit/BinNormalizerTest.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Composer\Json\Normalizer\BinNormalizer;
 use Ergebnis\Json\Normalizer\Json;
-use Localheinz\Composer\Json\Normalizer\BinNormalizer;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Composer\Json\Normalizer\BinNormalizer
+ * @covers \Ergebnis\Composer\Json\Normalizer\BinNormalizer
  */
 final class BinNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/ComposerJsonNormalizerTest.php
+++ b/test/Unit/ComposerJsonNormalizerTest.php
@@ -8,30 +8,30 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Composer\Json\Normalizer\BinNormalizer;
+use Ergebnis\Composer\Json\Normalizer\ComposerJsonNormalizer;
+use Ergebnis\Composer\Json\Normalizer\ConfigHashNormalizer;
+use Ergebnis\Composer\Json\Normalizer\PackageHashNormalizer;
+use Ergebnis\Composer\Json\Normalizer\VersionConstraintNormalizer;
 use Ergebnis\Json\Normalizer\ChainNormalizer;
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Normalizer\NormalizerInterface;
 use Ergebnis\Json\Normalizer\SchemaNormalizer;
-use Localheinz\Composer\Json\Normalizer\BinNormalizer;
-use Localheinz\Composer\Json\Normalizer\ComposerJsonNormalizer;
-use Localheinz\Composer\Json\Normalizer\ConfigHashNormalizer;
-use Localheinz\Composer\Json\Normalizer\PackageHashNormalizer;
-use Localheinz\Composer\Json\Normalizer\VersionConstraintNormalizer;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Composer\Json\Normalizer\ComposerJsonNormalizer
+ * @covers \Ergebnis\Composer\Json\Normalizer\ComposerJsonNormalizer
  *
- * @uses \Localheinz\Composer\Json\Normalizer\BinNormalizer
- * @uses \Localheinz\Composer\Json\Normalizer\ConfigHashNormalizer
- * @uses \Localheinz\Composer\Json\Normalizer\PackageHashNormalizer
- * @uses \Localheinz\Composer\Json\Normalizer\VersionConstraintNormalizer
+ * @uses \Ergebnis\Composer\Json\Normalizer\BinNormalizer
+ * @uses \Ergebnis\Composer\Json\Normalizer\ConfigHashNormalizer
+ * @uses \Ergebnis\Composer\Json\Normalizer\PackageHashNormalizer
+ * @uses \Ergebnis\Composer\Json\Normalizer\VersionConstraintNormalizer
  */
 final class ComposerJsonNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/ConfigHashNormalizerTest.php
+++ b/test/Unit/ConfigHashNormalizerTest.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Composer\Json\Normalizer\ConfigHashNormalizer;
 use Ergebnis\Json\Normalizer\Json;
-use Localheinz\Composer\Json\Normalizer\ConfigHashNormalizer;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Composer\Json\Normalizer\ConfigHashNormalizer
+ * @covers \Ergebnis\Composer\Json\Normalizer\ConfigHashNormalizer
  */
 final class ConfigHashNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/PackageHashNormalizerTest.php
+++ b/test/Unit/PackageHashNormalizerTest.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Composer\Json\Normalizer\PackageHashNormalizer;
 use Ergebnis\Json\Normalizer\Json;
-use Localheinz\Composer\Json\Normalizer\PackageHashNormalizer;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Composer\Json\Normalizer\PackageHashNormalizer
+ * @covers \Ergebnis\Composer\Json\Normalizer\PackageHashNormalizer
  */
 final class PackageHashNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/VersionConstraintNormalizerTest.php
+++ b/test/Unit/VersionConstraintNormalizerTest.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-json-normalizer
+ * @see https://github.com/ergebnis/composer-json-normalizer
  */
 
-namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Composer\Json\Normalizer\VersionConstraintNormalizer;
 use Ergebnis\Json\Normalizer\Json;
-use Localheinz\Composer\Json\Normalizer\VersionConstraintNormalizer;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Composer\Json\Normalizer\VersionConstraintNormalizer
+ * @covers \Ergebnis\Composer\Json\Normalizer\VersionConstraintNormalizer
  */
 final class VersionConstraintNormalizerTest extends AbstractNormalizerTestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the namespace `Localheinz\Composer\Json\Normalizer` to `Ergebnis\Composer\Json\Normalizer` after the move to @ergebnis